### PR TITLE
テスト対象を変更

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - $(npm bin)/mocha specifications/localhost

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
 machine:
   ruby:
     version: 2.2.2
+
+test:
+  override:
+    - bundle exec rake spec

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
-test:
-  override:
-    - $(npm bin)/mocha specifications/localhost
+machine:
+  ruby:
+    version: 2.2.2


### PR DESCRIPTION
CI 上で実行するテストを code-check 側で提供されたテストではなく、RSpec を実行するように変更。
Rails アプリケーションでテストしやすくするため。
